### PR TITLE
Fix static search route and custom Fumadocs-primitive components for v16

### DIFF
--- a/src/components/inline-toc.tsx
+++ b/src/components/inline-toc.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ChevronDown } from 'lucide-react';
-import type { TOCItemType } from 'fumadocs-core/server';
+import type { TOCItemType } from 'fumadocs-core/toc';
 import {
   Collapsible,
   CollapsibleContent,


### PR DESCRIPTION
## Summary

Reconciles the static search route and the three custom components that reach into Fumadocs internals directly with the v16 API surface. Of the four named integration points, only one had actually drifted:

- `src/app/api/search/route.ts`'s `createFromSource`/`staticGET` — unchanged in v16, no fix needed.
- `src/components/tabs.tsx`'s `useEffectEvent` — already fixed by the sibling PR #22 (load-bearing fix landed there since it was 500ing every docs page).
- `src/components/card.tsx`'s `Link` from `fumadocs-core/link` — unchanged in v16, no fix needed.
- `src/components/inline-toc.tsx` — `TOCItemType` moved from the removed `fumadocs-core/server` to `fumadocs-core/toc` (field shape unchanged). One-line import-path fix.

Note: the docs content actually wires `fumadocs-ui/components/inline-toc` (the built-in component), not this repo's custom `@/components/inline-toc` — so the custom component is unreached dead code in the rendered site, pre-existing and unrelated to this fix (called out already in #16's commit).

Closes #17

## Test plan

- [x] All four files typecheck against Fumadocs v16 types (tsc/eslint clean)
- [x] Static search route runs and returns results via `pnpm dev` (`/api/search?query=card` returns a populated index)
- [x] `pnpm dev`: `/docs/components` renders Tabs (tablist), Card (`data-card` links), InlineTOC ("Table of Contents" + items) without errors
- [x] code-review skill run against `origin/epic/13-fumadocs-stack-update`; both axes clean