### PR TITLE
Integrate and verify: full build + manual smoke check for Fumadocs v16

### DIFF
--- a/src/components/accordion.tsx
+++ b/src/components/accordion.tsx
@@ -29,6 +29,7 @@ export const Accordions = forwardRef<
 		const id = window.location.hash.substring(1)
 
 		if (id.length > 0)
+			// eslint-disable-next-line react-hooks/set-state-in-effect -- sync initial accordion value from the URL hash, only readable after mount
 			setValue((prev) => (typeof prev === 'string' ? id : [id, ...prev]))
 	}, [])
 

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -33,6 +33,7 @@ export function Banner({
   const globalKey = id ? `nd-banner-${id}` : null;
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync open state from localStorage, only readable after mount
     if (globalKey) setOpen(localStorage.getItem(globalKey) !== 'true');
   }, [globalKey]);
 

--- a/src/components/tabs.tsx
+++ b/src/components/tabs.tsx
@@ -90,6 +90,7 @@ export function Tabs({
       ? localStorage.getItem(groupId)
       : sessionStorage.getItem(groupId);
 
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- sync selected tab from persisted group storage, only readable after mount
     if (previous) onUpdate(previous);
     addChangeListener(groupId, onUpdate);
     return () => {
@@ -103,6 +104,7 @@ export function Tabs({
 
     for (const [value, id] of valueToIdMap.entries()) {
       if (id === hash) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- sync selected tab from the URL hash, only readable after mount
         setValue(value);
         break;
       }

--- a/src/content/docs/atelier/story-example-1/chapter-1/another-page-1.mdx
+++ b/src/content/docs/atelier/story-example-1/chapter-1/another-page-1.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-1/chapter-1/another-page-2.mdx
+++ b/src/content/docs/atelier/story-example-1/chapter-1/another-page-2.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-1/chapter-1/index.mdx
+++ b/src/content/docs/atelier/story-example-1/chapter-1/index.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-1/chapter-2/another-page-1.mdx
+++ b/src/content/docs/atelier/story-example-1/chapter-2/another-page-1.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-1/chapter-2/another-page-2.mdx
+++ b/src/content/docs/atelier/story-example-1/chapter-2/another-page-2.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-1/chapter-2/index.mdx
+++ b/src/content/docs/atelier/story-example-1/chapter-2/index.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-1/index.mdx
+++ b/src/content/docs/atelier/story-example-1/index.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-1/story-example-1-page-1.mdx
+++ b/src/content/docs/atelier/story-example-1/story-example-1-page-1.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/chapter-1/another-page-1.mdx
+++ b/src/content/docs/atelier/story-example-2/chapter-1/another-page-1.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/chapter-1/another-page-2.mdx
+++ b/src/content/docs/atelier/story-example-2/chapter-1/another-page-2.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/chapter-1/index.mdx
+++ b/src/content/docs/atelier/story-example-2/chapter-1/index.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/chapter-2/another-page-1.mdx
+++ b/src/content/docs/atelier/story-example-2/chapter-2/another-page-1.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/chapter-2/another-page-2.mdx
+++ b/src/content/docs/atelier/story-example-2/chapter-2/another-page-2.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/chapter-2/index.mdx
+++ b/src/content/docs/atelier/story-example-2/chapter-2/index.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/index.mdx
+++ b/src/content/docs/atelier/story-example-2/index.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/atelier/story-example-2/story-example-1-page-1.mdx
+++ b/src/content/docs/atelier/story-example-2/story-example-1-page-1.mdx
@@ -111,7 +111,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut
@@ -175,7 +175,7 @@ Ordered List
 
 <Slide slug="virtuelle-stadtstaaten" />
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2', 'Tab 3']}>
 	<Tab value="Tab 1">
 		Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
 		eirmod tempor invidunt ut

--- a/src/content/docs/components.mdx
+++ b/src/content/docs/components.mdx
@@ -40,7 +40,7 @@ import { Tabs, Tab } from '@/components/tabs'
 
 ## Tabs
 
-<Tabs>
+<Tabs items={['Tab 1', 'Tab 2']}>
 	<Tab value="Tab 1">Content for Tab 1</Tab>
 	<Tab value="Tab 2">Content for Tab 2</Tab>
 </Tabs>

--- a/src/lib/use-copy-button.ts
+++ b/src/lib/use-copy-button.ts
@@ -13,6 +13,7 @@ export function useCopyButton(
   const [checked, setChecked] = useState(false);
   const timeoutRef = useRef<number | null>(null);
   const callbackRef = useRef(onCopy);
+  // eslint-disable-next-line react-hooks/refs -- keep the latest callback available to onClick without adding it as an effect dependency
   callbackRef.current = onCopy;
 
   const onClick: MouseEventHandler = useCallback(() => {


### PR DESCRIPTION
## Summary

The epic's integration checkpoint (#18): confirms tickets #14-#17 work together end to end on the real build. `pnpm build` (next build + next-image-export-optimizer) completes with 0 errors — 57 static pages, 156 optimized images. Two pre-existing (pre-epic) issues surfaced during verification and were fixed since they block this ticket's own acceptance criteria:

- **eslint-plugin-react-hooks v7 findings** (5, in accordion.tsx/banner.tsx/tabs.tsx/use-copy-button.ts): elevated to errors by the eslint-config-next v16 bump (#21), explicitly deferred to this ticket by #21/#22's commit messages. Fixed with scoped, justified `eslint-disable-next-line` comments — matches fumadocs-ui v16's own unfixed upstream patterns and tabs.tsx's existing disable-comment convention.
- **Tabs `items` prop missing site-wide**: all 33 `<Tabs>` blocks across 17 MDX content files omitted the `items` prop the vendored Tabs component needs to render trigger buttons — Tabs switching was non-functional everywhere. Confirmed pre-existing (predates the epic, unchanged since Feb 2025 scaffold) via `git log`, not a v16 regression, but directly fails this ticket's "Tabs function" criterion. Fixed by mirroring each block's existing `Tab value="..."` labels into `items={[...]}`, one-for-one, no content invented.

**Not fixed, flagged for the maintainer**: sidebar tab colors for atelier/xeniapolis fall back to a shared default because `--atelier-color`/`--xeniapolis-color` CSS custom properties are never defined anywhere in the repo. No documented convention to derive values from, so left as a design decision rather than inventing colors.

Closes #18

## Test plan

- [x] `pnpm build` completes with no errors (57 static pages, 156 optimized images)
- [x] `pnpm dev` smoke check via curl against every acceptance-criteria route (no working browser in this Alpine/musl sandbox — Playwright's Chromium needs glibc/root): home page, `/docs` + atelier/xeniapolis pages, search index, Tabs triggers, Card links, optimized image serving (`image/webp`) all verified
- [x] No server-side console errors/warnings across any request
- [x] `pnpm-lock.yaml` unchanged and consistent (`pnpm install --frozen-lockfile` succeeds)
- [x] code-review skill run twice (Standards + Spec) against `origin/epic/13-fumadocs-stack-update`; clean on final diff

**Note for reviewer:** the smoke check here was curl-based, not an actual browser, due to sandbox constraints (see test plan). Worth a manual `pnpm dev` browser pass before closing out the epic.